### PR TITLE
Increase read_uchar_buffer sizes for Locale

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.0
+  - 2.4.6
+  - 2.5.5
+  - 2.6.3
   - ruby-head
 before_script:
   - sudo apt-get install -y libicu-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ rvm:
   - 2.1.0
   - ruby-head
 before_script:
-  - sudo apt-get install -y libicu48
+  - sudo apt-get install -y libicu-dev

--- a/lib/ffi-icu/locale.rb
+++ b/lib/ffi-icu/locale.rb
@@ -75,7 +75,7 @@ module ICU
     def display_country(locale = nil)
       locale = locale.to_s unless locale.nil?
 
-      Lib::Util.read_uchar_buffer(64) do |buffer, status|
+      Lib::Util.read_uchar_buffer(256) do |buffer, status|
         Lib.uloc_getDisplayCountry(@id, locale, buffer, buffer.size, status)
       end
     end
@@ -83,7 +83,7 @@ module ICU
     def display_language(locale = nil)
       locale = locale.to_s unless locale.nil?
 
-      Lib::Util.read_uchar_buffer(64) do |buffer, status|
+      Lib::Util.read_uchar_buffer(192) do |buffer, status|
         Lib.uloc_getDisplayLanguage(@id, locale, buffer, buffer.size, status)
       end
     end
@@ -91,7 +91,7 @@ module ICU
     def display_name(locale = nil)
       locale = locale.to_s unless locale.nil?
 
-      Lib::Util.read_uchar_buffer(64) do |buffer, status|
+      Lib::Util.read_uchar_buffer(256) do |buffer, status|
         Lib.uloc_getDisplayName(@id, locale, buffer, buffer.size, status)
       end
     end
@@ -99,7 +99,7 @@ module ICU
     def display_script(locale = nil)
       locale = locale.to_s unless locale.nil?
 
-      Lib::Util.read_uchar_buffer(64) do |buffer, status|
+      Lib::Util.read_uchar_buffer(128) do |buffer, status|
         Lib.uloc_getDisplayScript(@id, locale, buffer, buffer.size, status)
       end
     end

--- a/lib/ffi-icu/time_formatting.rb
+++ b/lib/ffi-icu/time_formatting.rb
@@ -1,3 +1,4 @@
+require 'date'
 
 module ICU
   module TimeFormatting

--- a/spec/locale_spec.rb
+++ b/spec/locale_spec.rb
@@ -111,7 +111,7 @@ module ICU
 
         it 'returns the script' do
           Locale.new('ja_Hira_JP').display_script('en').should == 'Hiragana'
-          Locale.new('ja_Hira_JP').display_script('ru').should == 'Хирагана'
+          Locale.new('ja_Hira_JP').display_script('ru').should == 'хирагана'
         end
 
         it 'returns the variant' do

--- a/spec/locale_spec.rb
+++ b/spec/locale_spec.rb
@@ -113,7 +113,7 @@ module ICU
 
         it 'returns the script' do
           Locale.new('ja_Hira_JP').display_script('en').should == 'Hiragana'
-          Locale.new('ja_Hira_JP').display_script('ru').should == 'Хирагана'
+          Locale.new('ja_Hira_JP').display_script('ru').should == 'хирагана'
         end
 
         it 'returns the variant' do

--- a/spec/locale_spec.rb
+++ b/spec/locale_spec.rb
@@ -93,6 +93,8 @@ module ICU
     end
 
     describe 'display' do
+      let(:locale_ids) { Locale.available.map(&:id) }
+
       context 'in a specific locale' do
         it 'returns the country' do
           Locale.new('de_DE').display_country('en').should == 'Germany'
@@ -111,12 +113,23 @@ module ICU
 
         it 'returns the script' do
           Locale.new('ja_Hira_JP').display_script('en').should == 'Hiragana'
-          Locale.new('ja_Hira_JP').display_script('ru').should == 'хирагана'
+          Locale.new('ja_Hira_JP').display_script('ru').should == 'Хирагана'
         end
 
         it 'returns the variant' do
           Locale.new('be_BY_TARASK').display_variant('de').should == 'Taraskievica-Orthographie'
           Locale.new('zh_CH_POSIX').display_variant('en').should == 'Computer'
+        end
+
+        # If memory set for 'read_uchar_buffer' is set too low it will throw an out
+        # of bounds memory error, which results in a Segmentation fault error.
+        it 'insures memory sizes is set correctly' do
+          # Currently, testing the longest known locales. May need to be update in the future.
+          Locale.new('en_VI').display_country('ccp').should_not be_nil
+          Locale.new('yue_Hant').display_language('ccp').should_not be_nil
+          Locale.new('en_VI').display_name('ccp').should_not be_nil
+          Locale.new('yue_Hant').display_script('ccp').should_not be_nil
+          Locale.new('en_US_POSIX').display_variant('sl').should_not be_nil
         end
       end
 


### PR DESCRIPTION
Increase the  `read_uchar_buffer` size for Locale: `display_script`, `display_country`, `display_language`, `display_name`

Depending on the locales you use it throws an out of bounds memory error, which results in a `Segmentation fault` error.

Currently, these are the max character byte sizes:
```
(dev)> ICU::Locale.new('en-VI').display_name('ccp')
IndexError: Memory access offset=0 size=180 is out of bounds
from /bundle/gems/ffi-icu-0.1.10/lib/ffi-icu/uchar.rb:41:in `read_array_of_uint16'
```

Longest character byte sizes:

```
display_script = ICU::Locale.new('yue_Hant').display_script('ccp')
display_script.bytesize # => 91
```
```
display_country = ICU::Locale.new('en_VI').display_country('ccp')
display_country.bytesize # => 209
```
```
display_language = ICU::Locale.new('zgh').display_language('ccp')
display_language.bytesize # => 151
```
```
display_name = ICU::Locale.new('en_VI').display_name('ccp')
display_name.bytesize # => 254
```